### PR TITLE
Integrate swift-composable-architecture

### DIFF
--- a/CodingPractice.xcodeproj/project.pbxproj
+++ b/CodingPractice.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		9B13895E27B5AA490070F53F /* WebServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13895D27B5AA490070F53F /* WebServiceError.swift */; };
 		9B13896227B5AA7B0070F53F /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13896127B5AA7B0070F53F /* DataProcessor.swift */; };
 		9B726E1D27C1090200A5EB80 /* ProductRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B726E1C27C1090200A5EB80 /* ProductRowCell.swift */; };
+		9BABAA8F28411D4100AECB8D /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 9BABAA8E28411D4100AECB8D /* ComposableArchitecture */; };
 		9BB6060427BAF02400D8E5D1 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060327BAF02400D8E5D1 /* Router.swift */; };
 		9BB6060627BAF1CE00D8E5D1 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060527BAF1CE00D8E5D1 /* ProductDetailViewController.swift */; };
 		9BB6060C27BAF3D500D8E5D1 /* MockRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060B27BAF3D500D8E5D1 /* MockRouting.swift */; };
@@ -94,6 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9BABAA8F28411D4100AECB8D /* ComposableArchitecture in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -244,6 +246,9 @@
 			dependencies = (
 			);
 			name = CodingPractice;
+			packageProductDependencies = (
+				9BABAA8E28411D4100AECB8D /* ComposableArchitecture */,
+			);
 			productName = CodingPractice;
 			productReference = 9B13894227B59EF10070F53F /* CodingPractice.app */;
 			productType = "com.apple.product-type.application";
@@ -295,6 +300,9 @@
 				Base,
 			);
 			mainGroup = 9B13893927B59EF10070F53F;
+			packageReferences = (
+				9BABAA8D28411D4100AECB8D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+			);
 			productRefGroup = 9B13894327B59EF10070F53F /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -641,6 +649,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9BABAA8D28411D4100AECB8D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-composable-architecture";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		9BABAA8E28411D4100AECB8D /* ComposableArchitecture */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9BABAA8D28411D4100AECB8D /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;
+			productName = ComposableArchitecture;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9B13893A27B59EF10070F53F /* Project object */;
 }

--- a/CodingPractice.xcodeproj/project.pbxproj
+++ b/CodingPractice.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		9B13896227B5AA7B0070F53F /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13896127B5AA7B0070F53F /* DataProcessor.swift */; };
 		9B726E1D27C1090200A5EB80 /* ProductRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B726E1C27C1090200A5EB80 /* ProductRowCell.swift */; };
 		9BABAA8F28411D4100AECB8D /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 9BABAA8E28411D4100AECB8D /* ComposableArchitecture */; };
+		9BABAA9128411F8D00AECB8D /* ComposableArchitecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BABAA9028411F8D00AECB8D /* ComposableArchitecture.swift */; };
 		9BB6060427BAF02400D8E5D1 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060327BAF02400D8E5D1 /* Router.swift */; };
 		9BB6060627BAF1CE00D8E5D1 /* ProductDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060527BAF1CE00D8E5D1 /* ProductDetailViewController.swift */; };
 		9BB6060C27BAF3D500D8E5D1 /* MockRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BB6060B27BAF3D500D8E5D1 /* MockRouting.swift */; };
@@ -64,6 +65,7 @@
 		9B13895D27B5AA490070F53F /* WebServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServiceError.swift; sourceTree = "<group>"; };
 		9B13896127B5AA7B0070F53F /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
 		9B726E1C27C1090200A5EB80 /* ProductRowCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowCell.swift; sourceTree = "<group>"; };
+		9BABAA9028411F8D00AECB8D /* ComposableArchitecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposableArchitecture.swift; sourceTree = "<group>"; };
 		9BB6060327BAF02400D8E5D1 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
 		9BB6060527BAF1CE00D8E5D1 /* ProductDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailViewController.swift; sourceTree = "<group>"; };
 		9BB6060B27BAF3D500D8E5D1 /* MockRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRouting.swift; sourceTree = "<group>"; };
@@ -130,6 +132,7 @@
 		9B13894427B59EF10070F53F /* CodingPractice */ = {
 			isa = PBXGroup;
 			children = (
+				9BABAA9228411F9800AECB8D /* ComposableArchitecture */,
 				9BD4A80927C25A7800349D41 /* Persistence */,
 				9B13895F27B5AA5E0070F53F /* WebService */,
 				9B13896027B5AA6C0070F53F /* Features */,
@@ -163,6 +166,14 @@
 				9BB6060327BAF02400D8E5D1 /* Router.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		9BABAA9228411F9800AECB8D /* ComposableArchitecture */ = {
+			isa = PBXGroup;
+			children = (
+				9BABAA9028411F8D00AECB8D /* ComposableArchitecture.swift */,
+			);
+			path = ComposableArchitecture;
 			sourceTree = "<group>";
 		};
 		9BB6060727BAF1D200D8E5D1 /* ProductDetail */ = {
@@ -339,6 +350,7 @@
 			files = (
 				9BB6060427BAF02400D8E5D1 /* Router.swift in Sources */,
 				9BF85ECB27B9303100E78364 /* WebService.swift in Sources */,
+				9BABAA9128411F8D00AECB8D /* ComposableArchitecture.swift in Sources */,
 				9BD4A80827C25A6F00349D41 /* Persistence.swift in Sources */,
 				9BFDB35027BEE179006327C3 /* ProductDetailEvent.swift in Sources */,
 				9BF85EB727B9295000E78364 /* ProductsViewModel.swift in Sources */,

--- a/CodingPractice.xcodeproj/project.pbxproj
+++ b/CodingPractice.xcodeproj/project.pbxproj
@@ -178,6 +178,14 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9B2B6DF82846081E0048498C /* ComposableArchitecture */ = {
+			isa = PBXGroup;
+			children = (
+				9B26FEF428428B060069291A /* ComposableArchitectureTests.swift */,
+			);
+			path = ComposableArchitecture;
+			sourceTree = "<group>";
+		};
 		9BABAA9228411F9800AECB8D /* ComposableArchitecture */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,10 +230,10 @@
 		9BD4A80C27C25F0700349D41 /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				9B2B6DF82846081E0048498C /* ComposableArchitecture */,
 				D810F8FC27BD1FB900F8DD78 /* ProductFeatureRepositoryTests.swift */,
 				9BF85EC627B92F5800E78364 /* ProductsViewModelTests.swift */,
 				9BFDB35127BEE223006327C3 /* ProductDetailViewModelTests.swift */,
-				9B26FEF428428B060069291A /* ComposableArchitectureTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";

--- a/CodingPractice.xcodeproj/project.pbxproj
+++ b/CodingPractice.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		9B13895C27B5A1220070F53F /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13895B27B5A1220070F53F /* Product.swift */; };
 		9B13895E27B5AA490070F53F /* WebServiceError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13895D27B5AA490070F53F /* WebServiceError.swift */; };
 		9B13896227B5AA7B0070F53F /* DataProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B13896127B5AA7B0070F53F /* DataProcessor.swift */; };
+		9B26FEF528428B060069291A /* ComposableArchitectureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B26FEF428428B060069291A /* ComposableArchitectureTests.swift */; };
 		9B726E1D27C1090200A5EB80 /* ProductRowCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B726E1C27C1090200A5EB80 /* ProductRowCell.swift */; };
 		9BABAA8F28411D4100AECB8D /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = 9BABAA8E28411D4100AECB8D /* ComposableArchitecture */; };
 		9BABAA9128411F8D00AECB8D /* ComposableArchitecture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BABAA9028411F8D00AECB8D /* ComposableArchitecture.swift */; };
@@ -64,6 +65,7 @@
 		9B13895B27B5A1220070F53F /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		9B13895D27B5AA490070F53F /* WebServiceError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebServiceError.swift; sourceTree = "<group>"; };
 		9B13896127B5AA7B0070F53F /* DataProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataProcessor.swift; sourceTree = "<group>"; };
+		9B26FEF428428B060069291A /* ComposableArchitectureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposableArchitectureTests.swift; sourceTree = "<group>"; };
 		9B726E1C27C1090200A5EB80 /* ProductRowCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowCell.swift; sourceTree = "<group>"; };
 		9BABAA9028411F8D00AECB8D /* ComposableArchitecture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposableArchitecture.swift; sourceTree = "<group>"; };
 		9BB6060327BAF02400D8E5D1 /* Router.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Router.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 				9B13894427B59EF10070F53F /* CodingPractice */,
 				9BF85EBE27B92F3500E78364 /* CodingPracticeTests */,
 				9B13894327B59EF10070F53F /* Products */,
+				9B26FEF628428BF00069291A /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -168,6 +171,13 @@
 			path = Features;
 			sourceTree = "<group>";
 		};
+		9B26FEF628428BF00069291A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		9BABAA9228411F9800AECB8D /* ComposableArchitecture */ = {
 			isa = PBXGroup;
 			children = (
@@ -215,6 +225,7 @@
 				D810F8FC27BD1FB900F8DD78 /* ProductFeatureRepositoryTests.swift */,
 				9BF85EC627B92F5800E78364 /* ProductsViewModelTests.swift */,
 				9BFDB35127BEE223006327C3 /* ProductDetailViewModelTests.swift */,
+				9B26FEF428428B060069291A /* ComposableArchitectureTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -278,6 +289,8 @@
 				9BF85EC227B92F3500E78364 /* PBXTargetDependency */,
 			);
 			name = CodingPracticeTests;
+			packageProductDependencies = (
+			);
 			productName = CodingPracticeTests;
 			productReference = 9BF85EBD27B92F3500E78364 /* CodingPracticeTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -386,6 +399,7 @@
 				D810F8FD27BD1FB900F8DD78 /* ProductFeatureRepositoryTests.swift in Sources */,
 				9BFDB35227BEE223006327C3 /* ProductDetailViewModelTests.swift in Sources */,
 				9BD4A80E27C25F1300349D41 /* MockPersistence.swift in Sources */,
+				9B26FEF528428B060069291A /* ComposableArchitectureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CodingPractice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CodingPractice.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,68 @@
+{
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "4cf088c29a20f52be0f2ca54992b492c54e0076b",
+        "version" : "0.5.3"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "ce9c0d897db8a840c39de64caaa9b60119cf4be8",
+        "version" : "0.8.1"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "48254824bb4248676bf7ce56014ff57b142b77eb",
+        "version" : "1.0.2"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "c307541328a636b9e8e25ac868d89be54a8f8dbf",
+        "version" : "0.35.0"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "c4f78db9b90ca57b7b6abc2223e235242739ea3c",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "2d6b7ffcc67afd9077fac5e5a29bcd6d39b71076",
+        "version" : "0.4.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "50a70a9d3583fe228ce672e8923010c8df2deddd",
+        "version" : "0.2.1"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
+++ b/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
@@ -3,6 +3,7 @@ import Foundation
 
 struct AppState: Equatable {
     var productRows: [ProductRowDisplayInfo] = []
+    var errorMessage: String = ""
 }
 
 enum AppAction: Equatable {
@@ -29,9 +30,13 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, e
             .catchToEffect(AppAction.productsResponse)
         
     case let .productsResponse(.success(products)):
+        state.productRows = products.map(ProductRowDisplayInfo.init(product:))
+        
         return .none
         
     case let .productsResponse(.failure(error)):
+        state.errorMessage = error.description
+        
         return .none
     }
 }

--- a/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
+++ b/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
@@ -32,6 +32,7 @@ enum AppAction: Equatable {
     case productsResponse(Result<[Product], AppError>)
     case tapProductRow(String)
     case presentProduct(Product)
+    case tapProductIsFavorite(String)
 }
 
 // TODO: Re-name XXXEnvironment
@@ -42,6 +43,7 @@ struct WebServiceClientEnvironment {
 struct PersistenceEnvironment {
     var storeProducts: ([Product]) -> Effect<[Product], Never>
     var getProduct: (String) -> Effect<Product, Never>
+    var toggleProductIsFavorited: (String) -> Effect<Product, Never>
 }
 
 struct AppEnvironment {
@@ -83,5 +85,13 @@ let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, e
         state.productDetail = ProductDetailDisplayInfo(product: product)
         
         return .none
+        
+    case let .tapProductIsFavorite(productId):
+        return environment
+            .persistence
+            .toggleProductIsFavorited(productId)
+            .receive(on: environment.mainQueue)
+            .map(AppAction.presentProduct)
+            .eraseToEffect()
     }
 }

--- a/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
+++ b/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
@@ -2,10 +2,10 @@ import ComposableArchitecture
 import Foundation
 
 struct AppState: Equatable {
-    var productRows: [ProductRowDisplayInfo]
+    var productRows: [ProductRowDisplayInfo] = []
 }
 
-enum AppAction {
+enum AppAction: Equatable {
     case fetchProducts
     case productsResponse(Result<[Product], WebServiceError>)
 }

--- a/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
+++ b/CodingPractice/ComposableArchitecture/ComposableArchitecture.swift
@@ -1,0 +1,37 @@
+import ComposableArchitecture
+import Foundation
+
+struct AppState: Equatable {
+    var productRows: [ProductRowDisplayInfo]
+}
+
+enum AppAction {
+    case fetchProducts
+    case productsResponse(Result<[Product], WebServiceError>)
+}
+
+struct WebServiceClientEnvironment {
+    var getProducts: () -> Effect<[Product], WebServiceError>
+}
+
+struct AppEnvironment {
+    var webServiceClient: WebServiceClientEnvironment
+    var mainQueue: AnySchedulerOf<DispatchQueue>
+}
+
+let appReducer = Reducer<AppState, AppAction, AppEnvironment> { state, action, environment in
+    switch action {
+    case .fetchProducts:
+        return environment
+            .webServiceClient
+            .getProducts()
+            .receive(on: environment.mainQueue)
+            .catchToEffect(AppAction.productsResponse)
+        
+    case let .productsResponse(.success(products)):
+        return .none
+        
+    case let .productsResponse(.failure(error)):
+        return .none
+    }
+}

--- a/CodingPractice/Features/ProductDetail/ProductDetailDisplayInfo.swift
+++ b/CodingPractice/Features/ProductDetail/ProductDetailDisplayInfo.swift
@@ -3,3 +3,11 @@ struct ProductDetailDisplayInfo: Equatable {
     let description: String
     let isFavorited: Bool
 }
+
+extension ProductDetailDisplayInfo {
+    init(product: Product) {
+        self.title = product.title
+        self.description = product.description
+        self.isFavorited = product.isFavorited
+    }
+}

--- a/CodingPractice/WebService/WebServiceError.swift
+++ b/CodingPractice/WebService/WebServiceError.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct WebServiceError: Error {
+struct WebServiceError: Error, Equatable {
     let context: String
     let reason: String
 }

--- a/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
+++ b/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
@@ -9,6 +9,12 @@ extension WebServiceClientEnvironment {
     }
 }
 
+extension PersistenceEnvironment {
+    static let unimplemented = Self { _ in
+        .failing("storeProducts has not been implemented")
+    }
+}
+
 private let fakeProducts: [Product] = [
     .init(
         id: "deedbeef-deed-beaf-deedbeefdeed",
@@ -30,6 +36,10 @@ extension WebServiceClientEnvironment {
     }
 }
 
+extension PersistenceEnvironment {
+    static let success = Self(storeProducts: Effect.init(value:))
+}
+
 final class ComposableArchitectureTests: XCTestCase {
     private let scheduler = DispatchQueue.test
     
@@ -39,7 +49,8 @@ final class ComposableArchitectureTests: XCTestCase {
             reducer: appReducer,
             environment: .init(
                 webServiceClient: .success,
-                mainQueue: scheduler.eraseToAnyScheduler()
+                mainQueue: scheduler.eraseToAnyScheduler(),
+                persistence: .success
             )
         )
         
@@ -57,7 +68,8 @@ final class ComposableArchitectureTests: XCTestCase {
             reducer: appReducer,
             environment: .init(
                 webServiceClient: .failure,
-                mainQueue: scheduler.eraseToAnyScheduler()
+                mainQueue: scheduler.eraseToAnyScheduler(),
+                persistence: .unimplemented
             )
         )
         

--- a/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
+++ b/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
@@ -76,9 +76,10 @@ final class ComposableArchitectureTests: XCTestCase {
         store.send(.fetchProducts)
         self.scheduler.advance()
         
-        store.receive(.productsResponse(.failure(webServiceError))) {
+        let appError = AppError(webServiceError: webServiceError)
+        store.receive(.productsResponse(.failure(appError))) {
             $0.productRows = []
-            $0.errorMessage = webServiceError.description
+            $0.errorMessage = appError.description
         }
     }
 }

--- a/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
+++ b/CodingPracticeTests/Features/ComposableArchitecture/ComposableArchitectureTests.swift
@@ -16,6 +16,9 @@ extension PersistenceEnvironment {
         },
         getProduct: { _ in
             .failing("getProduct has not been implemented")
+        },
+        toggleProductIsFavorited: { _ in
+            .failing("toggleProductIsFavorited has not been implemented")
         }
     )
 }
@@ -28,6 +31,15 @@ private let fakeProduct = Product(
 )
 
 private let fakeProducts: [Product] = [fakeProduct]
+
+private extension Product {
+    func toggleIsFavorite() -> Self {
+        var newProduct = self
+        newProduct.isFavorited.toggle()
+        
+        return newProduct
+    }
+}
 
 private let webServiceError = WebServiceError(context: "getContext", reason: "Failure")
 
@@ -46,6 +58,9 @@ extension PersistenceEnvironment {
         storeProducts: Effect.init(value:),
         getProduct: { _ in
             Effect(value: fakeProduct)
+        },
+        toggleProductIsFavorited: { _ in
+            Effect(value: fakeProduct.toggleIsFavorite())
         }
     )
 }
@@ -109,6 +124,25 @@ final class ComposableArchitectureTests: XCTestCase {
         
         store.receive(.presentProduct(fakeProduct)) {
             $0.productDetail = ProductDetailDisplayInfo(product: fakeProduct)
+        }
+    }
+    
+    func testTapProductIsFavorite() {
+        let store = TestStore(
+            initialState: .init(),
+            reducer: appReducer,
+            environment: .init(
+                webServiceClient: .unimplemented,
+                mainQueue: scheduler.eraseToAnyScheduler(),
+                persistence: .success
+            )
+        )
+        
+        store.send(.tapProductIsFavorite("deedbeef-deed-beaf-deedbeefdeed"))
+        scheduler.advance()
+        
+        store.receive(.presentProduct(fakeProduct.toggleIsFavorite())) {
+            $0.productDetail = ProductDetailDisplayInfo(product: fakeProduct.toggleIsFavorite())
         }
     }
 }

--- a/CodingPracticeTests/Features/ComposableArchitectureTests.swift
+++ b/CodingPracticeTests/Features/ComposableArchitectureTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import CodingPractice
 
 extension WebServiceClientEnvironment {
-    static let failing = Self {
+    static let unimplemented = Self {
         .failing("getProducts has not been implemented")
     }
 }
@@ -18,16 +18,22 @@ private let fakeProducts: [Product] = [
     )
 ]
 
+private let webServiceError = WebServiceError(context: "getContext", reason: "Failure")
+
 extension WebServiceClientEnvironment {
     static let success = Self {
         Effect(value: fakeProducts)
+    }
+    
+    static let failure = Self {
+        Effect(error: webServiceError)
     }
 }
 
 final class ComposableArchitectureTests: XCTestCase {
     private let scheduler = DispatchQueue.test
     
-    func testFetchProduct() {
+    func testFetchProductSuccess() {
         let store = TestStore(
             initialState: .init(),
             reducer: appReducer,
@@ -39,6 +45,28 @@ final class ComposableArchitectureTests: XCTestCase {
         
         store.send(.fetchProducts)
         self.scheduler.advance()
-        store.receive(.productsResponse(.success(fakeProducts)))
+        
+        store.receive(.productsResponse(.success(fakeProducts))) {
+            $0.productRows = fakeProducts.map(ProductRowDisplayInfo.init(product:))
+        }
+    }
+    
+    func testFetchProductFailure() {
+        let store = TestStore(
+            initialState: .init(),
+            reducer: appReducer,
+            environment: .init(
+                webServiceClient: .failure,
+                mainQueue: scheduler.eraseToAnyScheduler()
+            )
+        )
+        
+        store.send(.fetchProducts)
+        self.scheduler.advance()
+        
+        store.receive(.productsResponse(.failure(webServiceError))) {
+            $0.productRows = []
+            $0.errorMessage = webServiceError.description
+        }
     }
 }

--- a/CodingPracticeTests/Features/ComposableArchitectureTests.swift
+++ b/CodingPracticeTests/Features/ComposableArchitectureTests.swift
@@ -1,0 +1,44 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import CodingPractice
+
+extension WebServiceClientEnvironment {
+    static let failing = Self {
+        .failing("getProducts has not been implemented")
+    }
+}
+
+private let fakeProducts: [Product] = [
+    .init(
+        id: "deedbeef-deed-beaf-deedbeefdeed",
+        title: "Blob",
+        description: "This is Blob",
+        volume: 9
+    )
+]
+
+extension WebServiceClientEnvironment {
+    static let success = Self {
+        Effect(value: fakeProducts)
+    }
+}
+
+final class ComposableArchitectureTests: XCTestCase {
+    private let scheduler = DispatchQueue.test
+    
+    func testFetchProduct() {
+        let store = TestStore(
+            initialState: .init(),
+            reducer: appReducer,
+            environment: .init(
+                webServiceClient: .success,
+                mainQueue: scheduler.eraseToAnyScheduler()
+            )
+        )
+        
+        store.send(.fetchProducts)
+        self.scheduler.advance()
+        store.receive(.productsResponse(.success(fakeProducts)))
+    }
+}


### PR DESCRIPTION
## Summary
- Install `swift-composable-architecture` via SPM.
- Implement feature logic within `appReducer`.
- Cover feature logic with tests.